### PR TITLE
Path da extensão

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "advpl-unit-test",
     "displayName": "Advpl Unit Test",
     "description": "Suporte a teste unitario em ADVPL e VsCode",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "KillerAll",
     "extensionDependencies": [
         "KillerAll.advpl-vscode"

--- a/src/AdvplRunner.ts
+++ b/src/AdvplRunner.ts
@@ -12,17 +12,27 @@ export class AdvplRunner {
 
     constructor(jSonInfos : string )
     {
-        
+        let isAlpha: boolean = vscode.workspace.getConfiguration("advpl").get<boolean>("alpha_compile");
         this.EnvInfos = jSonInfos;
         this.debugPath = vscode.extensions.getExtension("KillerAll.advpl-vscode").extensionPath;
         this._result = "";
-        if(process.platform == "darwin")
+        if(process.platform == "win32")
         {
-            this.debugPath += "/bin/AdvplDebugBridgeMac";
+            if(isAlpha) {
+                this.debugPath += "\\bin\\alpha\\win\\AdvplDebugBridgeC.exe";
+            }
+            else {
+                this.debugPath += "\\bin\\AdvplDebugBridge.exe";
+            }
         }
         else
-        {   
-            this.debugPath += "\\bin\\AdvplDebugBridge.exe";
+        {
+            if(process.platform == "darwin") {
+                this.debugPath += "/bin/alpha/mac/AdvplDebugBridgeC";
+            }
+            else {
+                this.debugPath += "/bin/alpha/linux/AdvplDebugBridgeC";
+            }
         }
              
         


### PR DESCRIPTION
Correção do path do binário de debug, com a nova versão do Advpl-VSCode é possível ter o binário Alpha, que fica em outra pasta e possui outro nome.