### PR TITLE
Adicionado estrutura para receber informação de coverage e imprimir a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "KillerAll.advpl-vscode"
     ],
     "engines": {
-        "vscode": "^1.14.0"
+        "vscode": "^1.27.2"
     },
     "categories": [
         "Other"
@@ -42,7 +42,15 @@
                 "icon": {
                     "light": "resources/light/run.png",
                     "dark": "resources/dark/run.png"
-               }
+                }
+            },
+            {
+                "command": "advpl.unittest.showCoverage",
+                "title": "Advpl Unit Test - Show coverage on file."
+            },
+            {
+                "command": "advpl-unittest.removeCoverage",
+                "title": "Advpl Unit Test - Remove coverage on file."
             }
         ],
         "keybindings": [
@@ -56,41 +64,41 @@
         "views": {
             "test": [
                 {
-                "id": "advplTestExplorer",
-                "name": "Advpl Test Explorer"
+                    "id": "advplTestExplorer",
+                    "name": "Advpl Test Explorer"
                 }
             ]
         },
         "menus": {
             "view/title": [
                 {
-                "command": "advpl-unittest.refreshTestExplorer",
-                "when": "view == advplTestExplorer",
-                "group": "navigation@1"
+                    "command": "advpl-unittest.refreshTestExplorer",
+                    "when": "view == advplTestExplorer",
+                    "group": "navigation@1"
                 },
                 {
-                "command": "advpl-unittest.runAllTests",
-                "when": "view == advplTestExplorer",
-                "group": "navigation@0"
+                    "command": "advpl-unittest.runAllTests",
+                    "when": "view == advplTestExplorer",
+                    "group": "navigation@0"
                 }
             ],
             "view/item/context": [
                 {
-                "command": "advpl-unittest.runTest",
-                "when": "view == advplTestExplorer",
-                "group": "advplTestExplorer@0"
+                    "command": "advpl-unittest.runTest",
+                    "when": "view == advplTestExplorer",
+                    "group": "advplTestExplorer@0"
                 },
                 {
-                "command": "advpl-unittest.runTest",
-                "when": "view == advplTestExplorer",
-                "group": "inline"
+                    "command": "advpl-unittest.runTest",
+                    "when": "view == advplTestExplorer",
+                    "group": "inline"
                 }
             ]
         },
-        "configuration":{
+        "configuration": {
             "title": "AdvPL Test Explorer",
             "properties": {
-                "advpl-unittest.testDirectoryPath" :{
+                "advpl-unittest.testDirectoryPath": {
                     "type": "string",
                     "description": "Folder with advpl unit tests"
                 }
@@ -104,11 +112,11 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
+        "@types/mocha": "^2.2.32",
+        "@types/node": "^6.0.117",
+        "mocha": "^5.2.0",
         "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+        "vscode": "^1.1.21"
     },
     "repository": {
         "type": "git",
@@ -116,5 +124,8 @@
     },
     "bugs": {
         "url": "https://github.com/ragssoftwares/advpl-unit-test/issues"
+    },
+    "dependencies": {
+        "npm": "^6.4.1"
     }
 }

--- a/src/AdvplRunner.ts
+++ b/src/AdvplRunner.ts
@@ -2,6 +2,8 @@ import * as child_process from 'child_process';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import {LCov} from "coverage";
+
 export class AdvplRunner {
     private EnvInfos :string;
     private debugPath : string;
@@ -9,6 +11,7 @@ export class AdvplRunner {
     public _result : string;
     private afterExec;    
     private testResult;    
+    private lcov: LCov;
 
     constructor(jSonInfos : string )
     {
@@ -57,7 +60,7 @@ export class AdvplRunner {
             if(lRunned)            
             {
                 console.log("exit: " + data);
-                console.log("exit: " +that._result);
+                console.log("exit: " + that._result);
                 
                 try{
                     var obj = JSON.parse(that._result);
@@ -99,7 +102,7 @@ export class AdvplRunner {
             if(lRunned)            
             {
                 console.log("exit: " + data);
-                console.log("exit: " +that._result);
+                console.log("exit: " + that._result);
                 
                 try{
                     var obj = JSON.parse(that._result);
@@ -122,8 +125,14 @@ export class AdvplRunner {
     public process_result(obj)
     {
         var nMetodos = obj.methods;
-        this.testResult = obj;
-        console.log("process_result");        
+        this.testResult = obj.tests;
+        this.lcov = <LCov> obj.lcov;
+        console.log(obj.lcov);
+        console.log("process_result");
+    }
+
+    public getCoverage() :LCov {
+        return this.lcov;
     }
     public getResult()
     {

--- a/src/AdvplTestExplorer.ts
+++ b/src/AdvplTestExplorer.ts
@@ -66,7 +66,7 @@ export class AdvplTestExplorer implements TreeDataProvider<TestNode> {
             }else{
                 return new TestNode("", test, this.testResults);
             }
-        })
+        });
         /*if (!false) {
             vscode.window.showInformationMessage('No dependency in empty workspace');
             return Promise.resolve([]);

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -1,0 +1,24 @@
+declare module 'coverage'{
+
+  export interface Line {
+      DA: string;
+      hits: string;
+  }
+
+  export interface TN {
+      SF: string;
+      lines: Line[];
+      LH: string;
+      LF: string;
+  }
+
+  export interface LCov {
+      TNs: TN[];
+  }
+
+  export interface RootObject {
+      lcov: LCov;
+  }
+
+}
+

--- a/src/coverageAgent.ts
+++ b/src/coverageAgent.ts
@@ -1,0 +1,121 @@
+import {RendererCoverage} from './renderer';
+import * as vscode from 'vscode';
+import * as coverage from 'coverage';
+
+export class CoverageAgent{
+  private renderer :RendererCoverage;
+  private context: vscode.ExtensionContext;
+  private active:boolean;
+  private statusBarItem: vscode.StatusBarItem;
+  //private statusBarEditorWatcher: vscode.StatusBarItem;
+  private EditorWatcher: boolean;
+
+  constructor(context: vscode.ExtensionContext){
+    this.context = context;
+    this.active = false;
+    this.statusBarItem = vscode.window.createStatusBarItem();
+    this.statusBarItem.tooltip = "Show or remove coverage base on Application Server information -  LCOV."
+//    this.statusBarEditorWatcher = vscode.window.createStatusBarItem();
+//    this.statusBarEditorWatcher.tooltip = "Show coverage on active editor.";
+    vscode.window.onDidChangeActiveTextEditor(this.callRenderCoverage, this);  
+  }
+
+  public async displayCoverageForActiveFile() {
+    try {
+      this.EditorWatcher = true;
+      this.renderer.drawCoverage();
+      this.setRemoveCoverage();
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+  private callRenderCoverage(){
+    if (this.EditorWatcher){
+      this.renderer.drawCoverage();
+    }
+  }
+
+  private setRemoveCoverage(){
+    this.statusBarItem.command = "advpl.unittest.removeCoverage";
+    this.statusBarItem.text = "Remove Coverage on Active Editor."
+  }
+
+  public async removeCoverageForActiveFile() {
+    try {
+      
+      this.EditorWatcher = false;
+      this.renderer.removeDecorationsForEditor();
+      this.setDisplayCoverage();
+      
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  private setDisplayCoverage(){
+    this.statusBarItem.command = "advpl.unittest.showCoverage";
+    this.statusBarItem.text = "Display Coverage on Active Editor.";
+  }
+
+  private handleError(error: Error) {
+    const message = error.message ? error.message : error;
+    const stackTrace = error.stack;
+    const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel("Advpl Unit Test.");
+    vscode.window.showWarningMessage(message.toString());
+    outputChannel.appendLine(`[${Date.now()}][gutters]: Error ${message}`);
+    outputChannel.appendLine(`[${Date.now()}][gutters]: Stacktrace ${stackTrace}`);
+
+    if (error) {
+        console.error(message.toString());
+        console.error( stackTrace ? stackTrace.toString() : undefined);
+    }
+  }
+
+  public set newLCov(lCov:coverage.LCov){
+    console.log("Covered Files:");
+    for(const tn of lCov.TNs){
+      console.log(tn.SF);
+    }
+    
+    this.renderer = new RendererCoverage(lCov);
+  }
+
+  public activeAgent(){
+    if(this.active) return;
+    
+    const display = vscode.commands.registerCommand("advpl.unittest.showCoverage", () => {
+      this.displayCoverageForActiveFile();
+    });
+
+
+    const remove = vscode.commands.registerCommand("advpl.unittest.removeCoverage", () => {
+      this.removeCoverageForActiveFile();
+    });
+
+    this.context.subscriptions.push(remove);
+    this.context.subscriptions.push(display);
+
+    /*Create status bar button */
+    this.setDisplayCoverage();
+    this.context.subscriptions.push(this.statusBarItem);
+    this.statusBarItem.show();
+
+    /*const editorWatcherActive = vscode.commands.registerCommand("advpl.unittest.editorWatcherActive", () => {
+      this.displayCoverageForActiveFile();
+    });
+
+
+    const editorWatcherDesactive = vscode.commands.registerCommand("advpl.unittest.editorWatcherDesactive", () => {
+      this.removeCoverageForActiveFile();
+    });
+
+    this.context.subscriptions.push(editorWatcherActive);
+    this.context.subscriptions.push(editorWatcherDesactive);
+
+    this.context.subscriptions.push(this.statusBarEditorWatcher);
+    this.statusBarEditorWatcher.show();*/
+
+    this.active = true;
+    this.EditorWatcher = false;
+  }
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,0 +1,146 @@
+import * as vscode from 'vscode';
+import {Config}  from './config';
+import {Line, LCov} from "coverage";
+
+
+
+
+
+export class RendererCoverage {
+    private configStore: Config;
+    private lcov: LCov;
+    private decorator :Decorators;
+    constructor( lcov:LCov) {
+        this.lcov = lcov;
+        this.decorator = new Decorators();
+    }
+
+    public drawCoverage():boolean {
+        let found:boolean = false;
+        let textEditors = vscode.window.visibleTextEditors;
+        
+        for( let textEditor of textEditors) {
+            // Remove all decorations first to prevent graphical issues
+            
+            const doc = textEditor.document;
+
+            if ("advpl" === doc.languageId ) {
+
+                for (const tn of this.lcov.TNs) {
+                    if (doc.fileName === tn.SF) {
+                        found = true;
+                        this.clearDecorators(textEditor);
+                        this.setDecorationsForEditor(textEditor, tn.lines);
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    private clearDecorators(editor:vscode.TextEditor){
+        editor.setDecorations(
+            this.decorator.getCovered(),
+            []
+        );
+        editor.setDecorations(
+            this.decorator.getLineTocover(),
+            []
+        );
+    }
+    
+
+    public removeDecorationsForEditor(textEditor:vscode.TextEditor = null) {
+ 
+        this.decorator.decoratorReset();
+      
+    }
+
+    private setDecorationsForEditor( editor: vscode.TextEditor, lines: Array<Line>) {
+        
+        const lnDw = new LinesToDraw(lines);
+        
+        editor.setDecorations(
+            this.decorator.getCovered(),
+            lnDw.covered
+        );
+        editor.setDecorations(
+            this.decorator.getLineTocover(),
+            lnDw.noCovered
+        );
+/*         editor.setDecorations(
+            this.decorator.getCovered(),
+            lnDw.partial
+        ); */
+    }
+    
+    
+}
+
+class Decorators {
+    private covered: vscode.TextEditorDecorationType;
+    private lineTocover: vscode.TextEditorDecorationType;
+    private clearDecorator: vscode.TextEditorDecorationType;
+    constructor(){
+        this.initialize();
+    }
+
+    public getCovered() :vscode.TextEditorDecorationType {
+        return this.covered;
+    }
+
+    public getLineTocover() :vscode.TextEditorDecorationType {
+        return this.lineTocover;
+    }
+
+    public getClearDecorator() :vscode.TextEditorDecorationType {
+        return this.clearDecorator;
+    }
+
+    public decoratorReset(){
+        this.getCovered().dispose();
+        this.getLineTocover().dispose();
+        this.initialize();
+    }
+
+    private initialize(){
+        this.covered =  vscode.window.createTextEditorDecorationType({
+            backgroundColor: "rgba(45, 165, 10, 0.75)",
+            isWholeLine: true
+        });
+        this.lineTocover = vscode.window.createTextEditorDecorationType({
+            backgroundColor: "rgba(165, 10, 0, 0.75)",
+            isWholeLine: true
+        });
+        this.clearDecorator = vscode.window.createTextEditorDecorationType({
+            backgroundColor: "rgba(0, 0, 0, 0.75)",
+            isWholeLine: true
+        });
+    }
+}
+
+class LinesToDraw {
+    covered: vscode.Range[];
+    partial: vscode.Range[];
+    noCovered: vscode.Range[];
+
+    constructor(lines: Array<Line>){
+        this.covered = new Array<vscode.Range>();
+        this.partial = new Array<vscode.Range>();
+        this.noCovered = new Array<vscode.Range>();
+        
+        this.generateLinesCover(lines);
+    }
+
+    public generateLinesCover(lines: Array<Line>){
+
+        for(let line of lines){
+            const lineRange = new vscode.Range(Number(line.DA) - 1, 0, Number(line.DA) - 1, 0);
+            if (Number(line.hits) > 0) {
+                this.covered.push(lineRange);
+            } else {
+                this.noCovered.push(lineRange);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Necessário atualizar a extensão de advpl e a lib de tests.
O comando F1, com a entrada advpl listará os novos comandos assim, como o status bar item de display de coverage que aparece após a execução de um teste, habilita ou desabilita o display de coverage. 